### PR TITLE
Adding feature for grepping Out of Memory at the messages log

### DIFF
--- a/internals_help/executed_commands.txt
+++ b/internals_help/executed_commands.txt
@@ -50,6 +50,9 @@ cat $base_dir/proc/cpuinfo | grep processor | wc -l
 ## Messages"
 grep ERROR $base_dir/var/log/messages
 
+## Out of memory"
+grep 'Out of memory' $base_dir/var/log/messages
+
 ## Foreman Tasks"
 cat $base_dir/sos_commands/foreman/foreman-debug/foreman_tasks_tasks.csv | wc -l
 

--- a/sos_analyze.sh
+++ b/sos_analyze.sh
@@ -277,6 +277,15 @@ report()
   echo 																																				>> $FOREMAN_REPORT
 
 
+  echo "## Out of Memory"																													| tee -a $FOREMAN_REPORT
+  echo 																																				>> $FOREMAN_REPORT
+
+  echo "// out of memory"																							>> $FOREMAN_REPORT
+  echo "grep 'Out of memory' $base_dir/var/log/messages"																>> $FOREMAN_REPORT
+  echo "---"																																	>> $FOREMAN_REPORT
+  grep 'Out of memory' $base_dir/var/log/messages																				&>> $FOREMAN_REPORT
+  echo "---"																																	>> $FOREMAN_REPORT
+  echo 																																				>> $FOREMAN_REPORT
 
 
   echo "## Foreman Tasks"																																	| tee -a $FOREMAN_REPORT


### PR DESCRIPTION
To improve this script I am proposing to grep 'Out of memory' errors on the messages log.