### PR TITLE
Fix #23, query updated to 'Request queue is full' in error.log

### DIFF
--- a/sos_analyze.sh
+++ b/sos_analyze.sh
@@ -449,9 +449,9 @@ report()
   log
 
   log "// queues on error_log means the # of requests crossed the border. Satellite inaccessible"
-  log "grep queue $base_foreman/var/log/httpd/error_log | wc -l"
+  log "grep 'Request queue is full' $base_foreman/var/log/httpd/error_log | wc -l"
   log "---"
-  log_cmd "grep queue $base_foreman/var/log/httpd/error_log | wc -l"
+  log_cmd "grep 'Request queue is full' $base_foreman/var/log/httpd/error_log | wc -l"
   log "---"
   log
 


### PR DESCRIPTION
Query updated to `'Request queue is full'`