### PR TITLE
added getopts for option to copy report results to home dir(-c)

### DIFF
--- a/sos_analyze.sh
+++ b/sos_analyze.sh
@@ -6,6 +6,20 @@
 # Purpose ....: Analyze sosreport and summarize the information (focus on Satellite info)
 #
 
+
+while getopts "c" opt "${NULL[@]}"; do
+ case $opt in
+    c)
+    COPY_TO_CURRENT_DIR=true
+    ;;
+ esac
+done
+shift "$(($OPTIND -1))"
+
+MYPWD=$PWD
+
+
+
 FOREMAN_REPORT="/tmp/$$.log"
 
 main()
@@ -745,9 +759,9 @@ report()
 # cat virtwho/rpm_-V_virt-who 
 
 
-
-
-
+  if [ $COPY_TO_CURRENT_DIR ]; then
+    cp -v $FOREMAN_REPORT $MYPWD/report_${USER}_$final_name.log
+  fi
 
   mv $FOREMAN_REPORT /tmp/report_${USER}_$final_name.log
   echo 


### PR DESCRIPTION
A minimal set of changes to add basic getopts functionality.  An option(-c) was added to copy the report to the users directory where it was invoked from.  Getopts can be expanded in the future if wanted.  It does not change the existing default behavior.  At least in my testing.  

Example run:
$ mygitsos -c /path/to/sosreport
.
 <output not included>
.
 ## Foreman Settings
 ## PostgreSQL
‘/tmp/18049.log’ -> ‘/my/home/directory/where/sos_analyze/was/run/2019-10-03-qoxgnhj.log’


## Please check out the file /tmp/report_sosreport-2019-10-03-qoxgnhj.log
--
Users should not see any changes in functionality.   
