### PR TITLE
Update path for qpid -q for new sosreport version

### DIFF
--- a/sos_analyze.sh
+++ b/sos_analyze.sh
@@ -514,7 +514,7 @@ report()
   if [ "$sos_version" == "old" ];then
     cmd="grep -E '(  queue|  ===|katello_event_queue)' $base_dir/sos_commands/foreman/foreman-debug/qpid-stat-q"
   else
-    cmd="grep -E '(  queue|  ===|katello_event_queue)' $base_dir/sos_commands/qpid/qpid-stat_-q"
+    cmd="grep -E '(  queue|  ===|katello_event_queue)' $base_dir/sos_commands/katello/qpid-stat_-q_--ssl-certificate_.etc.pki.katello.qpid_client_striped.crt_-b_amqps_..localhost_5671"
   fi
 
   log "$cmd"
@@ -529,7 +529,7 @@ report()
   if [ "$sos_version" == "old" ];then
     cmd="cat $base_dir/sos_commands/foreman/foreman-debug/qpid-stat-q | grep pulp.agent | wc -l"
   else
-    cmd="cat $base_dir/sos_commands/qpid/qpid-stat_-q | grep pulp.agent | wc -l"
+    cmd="cat $base_dir/sos_commands/katello/qpid-stat_-q_--ssl-certificate_.etc.pki.katello.qpid_client_striped.crt_-b_amqps_..localhost_5671 | grep pulp.agent | wc -l"
   fi
 
   log "$cmd"
@@ -543,7 +543,7 @@ report()
   if [ "$sos_version" == "old" ];then
     cmd="cat $base_dir/sos_commands/foreman/foreman-debug/qpid-stat-q | grep pulp.agent | grep \" 1.*1\$\" | wc -l"
   else
-    cmd="cat $base_dir/sos_commands/qpid/qpid-stat_-q | grep pulp.agent | grep \" 1.*1\$\" | wc -l"
+    cmd="cat $base_dir/sos_commands/katello/qpid-stat_-q_--ssl-certificate_.etc.pki.katello.qpid_client_striped.crt_-b_amqps_..localhost_5671 | grep pulp.agent | grep \" 1.*1\$\" | wc -l"
   fi
 
   log "$cmd"


### PR DESCRIPTION
Update path for qpid -q for new sosreport version

In Satellite server, we must check the qpid files inside the sos_commands/katello directory, not inside sos_commands/qpid